### PR TITLE
Change community.md to link to the current location of contribution guide

### DIFF
--- a/community.md
+++ b/community.md
@@ -46,7 +46,7 @@ We use the Github issue tracker for bug reports and roadmap discussion.
 As a community project, we welcome contributions!
 The package is developed and used by the community.
 
-<a href="https://github.com/dmlc/xgboost/blob/master/doc/how_to/contribute.md" class="link-btn">XGBoost Contributor Guideline</a>
+<a href="https://github.com/dmlc/xgboost/blob/master/doc/contribute.rst" class="link-btn">XGBoost Contributor Guideline</a>
 
 <br>
 


### PR DESCRIPTION
Previous link is defunct as of [July 20th](https://github.com/dmlc/xgboost/commit/05b089405dc71dede7357e52a80d10bcea3a0d77).